### PR TITLE
Allow extensions and live reconfiguration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="light">
+<html class="dark">
   <head>
     <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=0">
 
@@ -8,6 +8,15 @@
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code&family=Inter:wght@300;400;700&display=swap">
     <style>
+      :root {
+        --ink-font-family: 'Inter', Helvetica, sans-serif;
+        --ink-font-family-mono: 'Fira Code', 'Courier New', Courier, monospace;
+      }
+
+      body {
+        font-family: var(--ink-font-family);
+      }
+
       .dark body {
         background-color: #171717;
         color: #fafafa;
@@ -22,9 +31,6 @@
         margin: auto;
         max-width: 75rem;
         padding: 0.5em;
-
-        --ink-font-family: 'Inter', Helvetica, sans-serif;
-        --ink-font-family-mono: 'Fira Code', 'Courier New', Courier, monospace;
       }
 
       #app .cm-editor.cm-focused {
@@ -33,6 +39,16 @@
     </style>
   </head>
   <body>
+    <div>
+      <label>
+        <input onclick="window.lightsOff()" type="radio" value="dark" name="appearance" checked>
+        <span>dark</span>
+      </label>
+      <label>
+        <input onclick="window.lightsOn()" type="radio" value="light" name="appearance">
+        <span>light</span>
+      </label>
+    </div>
     <div id="app"></div>
     <script type="module" src="/dist/es/index.js"></script>
     <script type="module">
@@ -42,13 +58,28 @@
 
       window.ink = ink(document.getElementById('app'), {
         appearance,
+        attribution: true,
         doc: '# Hello\n\nThis is an example doc. `hello`\n\n```js\nconst add = (a, b) => (a + b)\n```',
-        enableSpellcheck: true,
-        renderImages: true,
+        images: true,
+        spellcheck: true,
         onChange(value) {
           console.log(value)
         },
       })
+
+      window.lightsOn = () => {
+        document.documentElement.classList.remove('dark')
+        document.documentElement.classList.add('light')
+
+        window.ink.reconfigure({ appearance: 'light' })
+      }
+
+      window.lightsOff = () => {
+        document.documentElement.classList.remove('light')
+        document.documentElement.classList.add('dark')
+
+        window.ink.reconfigure({ appearance: 'dark' })
+      }
     </script>
   </body>
 </html>

--- a/src/extensions/appearance.ts
+++ b/src/extensions/appearance.ts
@@ -1,0 +1,14 @@
+import { Extension } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+
+export const dark = (): Extension => {
+  return [
+    EditorView.theme({}, { dark: true }),
+  ]
+}
+
+export const light = (): Extension => {
+  return [
+    EditorView.theme({}, { dark: false }),
+  ]
+}

--- a/src/extensions/attribution.ts
+++ b/src/extensions/attribution.ts
@@ -38,6 +38,12 @@ class AttributionWidget extends WidgetType {
   }
 }
 
+const attributionTheme = EditorView.baseTheme({
+  '.cm-content': {
+    paddingBottom: '2em',
+  },
+})
+
 const attributionField = StateField.define<DecorationSet>({
   create(state) {
     return RangeSet.of(decoration().range(state.doc.length))
@@ -58,6 +64,7 @@ const decoration = () => Decoration.widget({
 
 export const attribution = (): Extension => {
   return [
+    attributionTheme,
     attributionField,
   ]
 }

--- a/src/extensions/images.ts
+++ b/src/extensions/images.ts
@@ -2,65 +2,60 @@ import { syntaxTree } from '@codemirror/language'
 import { Range, RangeSet } from '@codemirror/rangeset'
 import { EditorState, Extension, StateField } from '@codemirror/state'
 import { Decoration, DecorationSet, EditorView, WidgetType } from '@codemirror/view'
-import { InkOptions } from '../types/ink'
 
 interface ImageWidgetParams {
   url: string
 }
 
-export const images = ({ appearance }: InkOptions): Extension => {
-  class ImageWidget extends WidgetType {
-    readonly url
+class ImageWidget extends WidgetType {
+  readonly url
 
-    constructor({ url }: ImageWidgetParams) {
-      super()
+  constructor({ url }: ImageWidgetParams) {
+    super()
 
-      this.url = url
-    }
-
-    eq(imageWidget: ImageWidget) {
-      return imageWidget.url === this.url
-    }
-
-    toDOM() {
-      const container = document.createElement('div')
-      const backdrop = container.appendChild(document.createElement('div'))
-      const figure = backdrop.appendChild(document.createElement('figure'))
-      const image = figure.appendChild(document.createElement('img'))
-
-      container.setAttribute('aria-hidden', 'true')
-      container.className = 'cm-image-container'
-      backdrop.className = 'cm-image-backdrop'
-      figure.className = 'cm-image-figure'
-      image.className = 'cm-image-img'
-      image.src = this.url
-
-      container.style.paddingBottom = '0.5rem'
-      container.style.paddingTop = '0.5rem'
-
-      if (appearance === 'dark') {
-        backdrop.style.backgroundColor = 'var(--ink-image-background-color, rgba(0, 0, 0, 0.2))'
-      } else {
-        backdrop.style.backgroundColor = 'var(--ink-image-background-color, rgba(0, 0, 0, 0.05))'
-      }
-
-      backdrop.style.borderRadius = 'var(--ink-image-border-radius, 0.25rem)'
-      backdrop.style.display = 'flex'
-      backdrop.style.alignItems = 'center'
-      backdrop.style.justifyContent = 'center'
-      backdrop.style.padding = '1rem'
-      backdrop.style.maxWidth = '100%'
-
-      figure.style.margin = '0'
-
-      image.style.display = 'block'
-      image.style.maxHeight = 'var(--ink-images-max-height, 20rem)'
-      image.style.maxWidth = '100%'
-
-      return container
-    }
+    this.url = url
   }
 
+  eq(imageWidget: ImageWidget) {
+    return imageWidget.url === this.url
+  }
+
+  toDOM() {
+    const container = document.createElement('div')
+    const backdrop = container.appendChild(document.createElement('div'))
+    const figure = backdrop.appendChild(document.createElement('figure'))
+    const image = figure.appendChild(document.createElement('img'))
+
+    container.setAttribute('aria-hidden', 'true')
+    container.className = 'cm-image-container'
+    backdrop.className = 'cm-image-backdrop'
+    figure.className = 'cm-image-figure'
+    image.className = 'cm-image-img'
+    image.src = this.url
+
+    container.style.paddingBottom = '0.5rem'
+    container.style.paddingTop = '0.5rem'
+
+    backdrop.classList.add('cm-image-backdrop')
+
+    backdrop.style.borderRadius = 'var(--ink-image-border-radius, 0.25rem)'
+    backdrop.style.display = 'flex'
+    backdrop.style.alignItems = 'center'
+    backdrop.style.justifyContent = 'center'
+    backdrop.style.padding = '1rem'
+    backdrop.style.maxWidth = '100%'
+
+    figure.style.margin = '0'
+
+    image.style.display = 'block'
+    image.style.maxHeight = 'var(--ink-images-max-height, 20rem)'
+    image.style.maxWidth = '100%'
+
+    return container
+  }
+}
+
+export const images = (): Extension => {
   const imageRegex = /!\[.*\]\((?<url>.*)\)/
 
   const imageDecoration = (imageWidgetParams: ImageWidgetParams) => Decoration.widget({
@@ -87,7 +82,16 @@ export const images = ({ appearance }: InkOptions): Extension => {
     return widgets.length > 0 ? RangeSet.of(widgets) : Decoration.none
   }
 
-  const imageField = StateField.define<DecorationSet>({
+  const imagesTheme = EditorView.baseTheme({
+    '&dark .cm-image-backdrop': {
+      backgroundColor: 'var(--ink-image-background-color, rgba(0, 0, 0, 0.2))',
+    },
+    '&light .cm-image-backdrop': {
+      backgroundColor: 'var(--ink-image-background-color, rgba(0, 0, 0, 0.05))',
+    },
+  })
+
+  const imagesField = StateField.define<DecorationSet>({
     create(state) {
       return decorate(state)
     },
@@ -104,6 +108,7 @@ export const images = ({ appearance }: InkOptions): Extension => {
   })
 
   return [
-    imageField,
+    imagesTheme,
+    imagesField,
   ]
 }

--- a/src/extensions/theme.ts
+++ b/src/extensions/theme.ts
@@ -3,7 +3,7 @@ import { Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
 import { InkOptions } from '../types/ink'
 
-export const theme = ({ appearance, disableAttribution }: InkOptions): Extension => {
+export const theme = (): Extension => {
   const baseTheme = EditorView.baseTheme({
     '&': {
       color: 'inherit',
@@ -13,14 +13,10 @@ export const theme = ({ appearance, disableAttribution }: InkOptions): Extension
       lineHeight: 'var(--ink-line-height, 2em)',
       fontSize: 'var(--ink-font-size, 1.1em)',
     },
-    '.cm-content': disableAttribution ? {} : {
-      paddingBottom: '2em',
-    },
     '.cm-line': {
       padding: '0',
     },
   })
-  const appearanceTheme = EditorView.theme({}, { dark: appearance === 'dark' })
   const syntaxHighlighting = HighlightStyle.define([
     // ordered by lowest to highest precedence
     {
@@ -176,7 +172,6 @@ export const theme = ({ appearance, disableAttribution }: InkOptions): Extension
 
   return [
     baseTheme,
-    appearanceTheme,
     syntaxHighlighting,
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,56 @@
-import { Transaction } from '@codemirror/state'
+import { Compartment, Transaction } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
+import { dark, light } from './extensions/appearance'
+import { attribution } from './extensions/attribution'
+import { images } from './extensions/images'
+import { spellcheck } from './extensions/spellcheck'
 
 import { createState } from './state'
 import * as Types from './types/ink'
 
-const ink = (parentElement: HTMLElement, unsafeOptions: Types.InkUnsafeOptions): Types.Ink => {
+const ink = (parent: HTMLElement, unsafeOptions: Types.InkUnsafeOptions): Types.Ink => {
   const options: Types.InkOptions = {
     appearance: 'dark',
-    disableAttribution: false,
+    attribution: true,
     doc: '',
-    enableSpellcheck: true,
+    extensions: [],
+    images: false,
+    spellcheck: true,
     onChange: () => {},
-    renderImages: false,
     ...unsafeOptions,
   }
 
+  const configurables: Types.InkConfigurables = {
+    appearance: {
+      build: (appearance) => (appearance === 'dark' ? dark() : light()),
+      compartment: new Compartment(),
+      default: options.appearance,
+    },
+    attribution: {
+      build: (enabled) => (enabled ? attribution() : []),
+      compartment: new Compartment(),
+      default: options.attribution,
+    },
+    images: {
+      build: (enabled) => (enabled ? images() : []),
+      compartment: new Compartment(),
+      default: options.images,
+    },
+    spellcheck: {
+      build: (enabled) => (enabled ? spellcheck() : []),
+      compartment: new Compartment(),
+      default: options.spellcheck,
+    },
+  }
+
+  const extensions = Object.entries(configurables).map(([_option, configurable]) => {
+    return configurable.compartment.of(configurable.build(configurable.default))
+  }).concat(options.extensions)
+
+  const state = createState(options, extensions)
   const view = new EditorView({
-    parent: parentElement,
-    state: createState(options),
+    parent,
+    state,
     dispatch(transaction: Transaction) {
       view.update([transaction])
 
@@ -40,7 +73,8 @@ const ink = (parentElement: HTMLElement, unsafeOptions: Types.InkUnsafeOptions):
       }
     },
     load(doc: string) {
-      view.setState(createState({ ...options, doc }))
+      // todo: use latest configuration instead of initial extensions
+      view.setState(createState({ ...options, doc }, extensions))
     },
     select(selection) {
       view.dispatch(
@@ -62,6 +96,22 @@ const ink = (parentElement: HTMLElement, unsafeOptions: Types.InkUnsafeOptions):
           },
         })
       )
+    },
+    reconfigure(updates: Types.InkUpdatableOptions) {
+      const effects = []
+
+      if (updates.appearance)
+        effects.push(configurables.appearance.compartment.reconfigure(configurables.appearance.build(updates.appearance)))
+      if (updates.attribution)
+        effects.push(configurables.attribution.compartment.reconfigure(configurables.attribution.build(updates.attribution)))
+      if (updates.images)
+        effects.push(configurables.images.compartment.reconfigure(configurables.images.build(updates.images)))
+      if (updates.spellcheck)
+        effects.push(configurables.spellcheck.compartment.reconfigure(configurables.spellcheck.build(updates.spellcheck)))
+
+      view.dispatch({
+        effects,
+      })
     },
   }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,27 +1,19 @@
 import { history } from '@codemirror/history'
-import { Compartment, EditorState } from '@codemirror/state'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
 import { languages } from '@codemirror/language-data'
+import { EditorState, Extension } from '@codemirror/state'
 
 import { code } from './extensions/code'
-import { images } from './extensions/images'
 import { keymaps } from './extensions/keymaps'
 import { lineWrapping } from './extensions/line_wrapping'
-import { attribution } from './extensions/attribution'
-import { spellcheck } from './extensions/spellcheck'
 import { theme } from './extensions/theme'
 import { InkOptions } from './types/ink'
 
-export const createState = (options: InkOptions): EditorState => {
-  const renderImages = new Compartment()
-  const enableAttribution = new Compartment()
-  const enableSpellcheck = new Compartment()
-
+export const createState = (options: InkOptions, extensions: Extension[] = []): EditorState => {
   return EditorState.create({
     doc: options.doc,
     selection: options.selection,
     extensions: [
-      theme(options),
       history(),
       markdown({
         base: markdownLanguage,
@@ -30,9 +22,8 @@ export const createState = (options: InkOptions): EditorState => {
       code(),
       keymaps(),
       lineWrapping(),
-      enableAttribution.of(options.disableAttribution ? [] : attribution()),
-      enableSpellcheck.of(options.enableSpellcheck ? spellcheck() : []),
-      renderImages.of(options.renderImages ? images(options) : []),
+      theme(),
+      ...extensions,
     ],
   })
 }

--- a/src/types/ink.ts
+++ b/src/types/ink.ts
@@ -1,33 +1,56 @@
-import { EditorSelection } from '@codemirror/state'
+import { Compartment, EditorSelection, Extension } from '@codemirror/state'
 
-type Appearance = 'dark' | 'light'
+export type InkAppearance = 'dark' | 'light'
+export type InkUpdatableOption = 'appearance' | 'attribution' | 'images' | 'spellcheck'
 
 export interface Ink {
   destroy: () => void
   doc: () => string
   focus: () => void
   load: (doc: string) => void
+  reconfigure: (updates: InkUpdatableOptions) => void
   select: (selection: EditorSelection) => void
   selection: () => EditorSelection
   update: (doc: string) => void
 }
 
 export interface InkOptions {
-  appearance: Appearance
-  disableAttribution: boolean
+  appearance: InkAppearance
+  attribution: boolean
   doc: string
-  enableSpellcheck: boolean
+  extensions: Extension[]
+  images: boolean
+  spellcheck: boolean
   onChange: (doc: string) => void
-  renderImages: boolean
   selection?: EditorSelection
 }
 
 export interface InkUnsafeOptions {
-  appearance?: Appearance
-  disableAttribution?: boolean
+  appearance?: InkAppearance
+  attribution?: boolean
   doc?: string
-  enableSpellcheck?: boolean
-  onChange?: (doc: string) => void
-  renderImages?: boolean
+  images?: boolean
   selection?: EditorSelection
+  spellcheck?: boolean
+  onChange?: (doc: string) => void
+}
+
+export interface InkUpdatableOptions {
+  appearance?: InkAppearance
+  attribution?: boolean
+  images?: boolean
+  spellcheck?: boolean
+}
+
+export interface InkConfigurable {
+  build: (value: any) => Extension
+  compartment: Compartment
+  default: any
+}
+
+export interface InkConfigurables {
+  appearance: InkConfigurable
+  attribution: InkConfigurable
+  images: InkConfigurable
+  spellcheck: InkConfigurable
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,9 +326,9 @@
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/node@*":
-  version "16.4.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.13.tgz#7dfd9c14661edc65cccd43a29eb454174642370d"
-  integrity sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==
+  version "16.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.1.tgz#c6b9198178da504dfca1fd0be9b2e1002f1586f0"
+  integrity sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A==
 
 "@types/resolve@1.17.1":
   version "1.17.1"
@@ -431,9 +431,9 @@ is-binary-path@~2.1.0:
     binary-extensions "^2.0.0"
 
 is-core-module@^2.2.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.5.0.tgz#f754843617c70bfd29b7bd87327400cda5c18491"
-  integrity sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.6.0.tgz#d7553b2526fe59b92ba3e40c8df757ec8a709e19"
+  integrity sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==
   dependencies:
     has "^1.0.3"
 
@@ -618,9 +618,9 @@ rollup-plugin-serve@^1.1.0:
     opener "1"
 
 rollup@^2.43.0:
-  version "2.56.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.56.1.tgz#f29dbc04a5d532dfa904f76b62395f359506211e"
-  integrity sha512-KkrsNjeiTfGJMUFBi/PNfj3fnt70akqdoNXOjlzwo98uA1qrlkmgt6SGaK5OwhyDYCVnJb6jb2Xa2wbI47P4Nw==
+  version "2.56.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.56.2.tgz#a045ff3f6af53ee009b5f5016ca3da0329e5470f"
+  integrity sha512-s8H00ZsRi29M2/lGdm1u8DJpJ9ML8SUOpVVBd33XNeEeL3NVaTiUcSBHzBdF3eAyR0l7VSpsuoVUGrRHq7aPwQ==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -637,9 +637,9 @@ to-regex-range@^5.0.1:
     is-number "^7.0.0"
 
 tslib@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
-  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 typescript@^4.2.3:
   version "4.3.5"


### PR DESCRIPTION
This PR adds the ability to supply [CodeMirror 6 extensions](https://codemirror.net/6/examples/zebra/) to extend the Ink editor. It also adds the ability to reconfigure Ink settings on the fly.

```js
const parent = document.getElementById('editor')
const instance = ink(parent, { appearance: 'dark' })

instance.reconfigure({ appearance: 'light' })
```