### PR TITLE
Enable linkWorkspacePackages and update the ink-mde dependency to prevent installation issues on StackBlitz.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 ignore-workspace-root-check=true
 include-workspace-root=true
+link-workspace-packages=true

--- a/examples/template-ts/package.json
+++ b/examples/template-ts/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "ink-mde": "workspace:*"
+    "ink-mde": "^0.34.0"
   },
   "devDependencies": {
     "typescript": "^5.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
   examples/template-ts:
     dependencies:
       ink-mde:
-        specifier: workspace:*
+        specifier: ^0.34.0
         version: link:../..
     devDependencies:
       typescript:
@@ -152,7 +152,7 @@ importers:
   svelte:
     dependencies:
       ink-mde:
-        specifier: workspace:*
+        specifier: ^0.34.0
         version: link:..
     devDependencies:
       '@sveltejs/adapter-auto':

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -30,6 +30,6 @@
   "main": "./dist/index.js",
   "type": "module",
   "dependencies": {
-    "ink-mde": "workspace:*"
+    "ink-mde": "^0.34.0"
   }
 }


### PR DESCRIPTION
relates to #98 