### PR TITLE
Implement instance API call to get the underlying CodeMirror instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A beautiful, modern, customizable Markdown editor powered by CodeMirror 6 and Ty
 - [x] Inline Markdown image previews
 - [x] Configurable and stylable
 - [x] An optional formatting toolbar (great for mobile)
-- [x] Optionally enable Vim Mode
+- [x] Optionally enable and configure Vim Mode
 - [x] Framework agnostic
 - [x] Vue wrapper (`ink-mde/vue` subpath export)
 - [x] Svelte wrapper (`ink-mde/svelte` subpath export)
@@ -283,6 +283,33 @@ const options = {
   trapTab: undefined,
   vim: false,
 }
+```
+
+### Configuring Vim
+
+Ink uses the lovely [@replit/codemirror-vim](https://github.com/replit/codemirror-vim) package to provide Vim bindings.
+Once you have `vim` set to `true` in your Ink instance, you can use the `getCM()` method and the
+[codemirror-vim extension api](https://github.com/replit/codemirror-vim?tab=readme-ov-file#usage-of-cm5-vim-extension-api)
+to configure your own key bindings.
+
+```javascript
+import { Vim } from '@replit/codemirror-vim'
+
+// Use `await` otherwise your editor instance may not be initialized
+const instance = await ink(document.createElement('div'), { vim: true })
+const cm = instance.getCM()
+
+// Mandatory key mapping
+Vim.exitInsertMode(cm)
+Vim.handleKey(cm, '<Esc>')
+
+// Now you can define your own key mappings
+Vim.map('jj', '<Esc>', 'insert'); // in insert mode
+Vim.map('Y', 'y$', 'normal'); // in normal mode
+
+Vim.defineEx('write', 'w', function() {
+  // Do something when the user does :w
+});
 ```
 
 ### Plugins

--- a/src/api/get_cm.ts
+++ b/src/api/get_cm.ts
@@ -1,0 +1,10 @@
+import { type EditorView } from '@codemirror/view'
+import { type CodeMirror } from '@replit/codemirror-vim'
+import type InkInternal from '/types/internal'
+
+type EditorViewExtended = EditorView & { cm: CodeMirror }
+
+export const getCM = ([state]: InkInternal.Store) => {
+  const { editor } = state()
+  return (editor as EditorViewExtended).cm
+}

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -15,6 +15,7 @@ import {
 import { awaitable } from '/src/utils/awaitable'
 import type * as Ink from '/types/ink'
 import type InkInternal from '/types/internal'
+import { getCM } from './api/get_cm'
 
 export const makeInstance = (store: InkInternal.Store): Ink.AwaitableInstance => {
   const instance = {
@@ -22,6 +23,7 @@ export const makeInstance = (store: InkInternal.Store): Ink.AwaitableInstance =>
     focus: focus.bind(undefined, store),
     format: format.bind(undefined, store),
     getDoc: getDoc.bind(undefined, store),
+    getCM: getCM.bind(undefined, store),
     insert: insert.bind(undefined, store),
     load: load.bind(undefined, store),
     options: options.bind(undefined, store),

--- a/test/unit/src/index.test.ts
+++ b/test/unit/src/index.test.ts
@@ -24,6 +24,12 @@ describe('ink', () => {
       expect(instance.getDoc()).toEqual('# Hello')
     })
 
+    it('returns the codemirror instance', async () => {
+      const instance = await wrap(document.createElement('textarea'), { vim: true })
+
+      expect(instance.getCM()).toBeDefined()
+    })
+
     it('can be reconfigured', () => {
       const instance = ink(document.createElement('div'), {
         interface: {

--- a/types/ink.ts
+++ b/types/ink.ts
@@ -3,6 +3,7 @@ import { type CompletionSource } from '@codemirror/autocomplete'
 import { type LanguageDescription } from '@codemirror/language'
 import { type Extension } from '@codemirror/state'
 import { type MarkdownConfig } from '@lezer/markdown'
+import { type CodeMirror } from '@replit/codemirror-vim'
 import type * as InkValues from './values'
 
 export type VendorCompletion = CompletionSource
@@ -27,6 +28,7 @@ export interface Instance {
   focus: () => void,
   format: (type: EnumString<InkValues.Markup>, options: Instance.FormatOptions) => void,
   getDoc: () => string,
+  getCM: () => undefined | CodeMirror,
   insert: (text: string, selection?: Editor.Selection) => void,
   load: (doc: string) => void,
   options: () => OptionsResolved,


### PR DESCRIPTION
Per issue #82 I've added a quick getter so that people (ie, me) can configure their own vim key bindings within ink!

Thanks for a neat project, I hope the tests aren't too barebones 😆 